### PR TITLE
clarify the dusts-v2 proposal

### DIFF
--- a/proposals/release-versioning-testing-v2.md
+++ b/proposals/release-versioning-testing-v2.md
@@ -1,6 +1,6 @@
-# Upgrade Testing V2<a id="sec-1" name="sec-1"></a>
+# Upgrade Testing V2
 
-## Updates from [the previous version](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md)<a id="sec-1-1" name="sec-1-1"></a>
+## Updates from [the previous version](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md)
 
 We revisit release version testing and the current upgrade testing strategy (the DUSTs) with the following changes and considerations in mind:
 
@@ -9,67 +9,106 @@ We revisit release version testing and the current upgrade testing strategy (the
 - Breaking changes to other systems in a CF deployment have caused the DUSTs to fail much more often than an actual breaking change between the APIs or components under the control of the Diego team.
 - Reliance on BOSH makes the initial deploy and subsequent updates slow. An inigo-style test suite written in Ginkgo could allow the Diego team to iterate faster and to run more focused subset of the test suite.
 
-## Aspects remaining from [the previous version](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md)<a id="sec-1-2" name="sec-1-2"></a>
+## Aspects remaining from [the previous version](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md)
 
-- We perceive there to be value in maintaining deployments at different heterogeneous combinations of versions and running an appropriate set of tests to validate functionality, instead of coincidentally running tests while proceeding through an upgrade of a single BOSH deployment.
-- Operational guarantees have not changed regarding compatibility of versions of diego-release. Refer to [this section](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md#operational-guarantees) in the original version of the document.
-- We still do not require testing every possible upgrade path (i.e. every `(V0, V1)` pair) See [this section](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md#selection-of-versions-for-testing) for the rationale.
+<!-- # Tests to run -->
 
+<!-- ## Long running tests -->
 
-# Tests to run<a id="sec-2" name="sec-2"></a>
+<!-- - As in the current [DUSTs](https://github.com/cloudfoundry/diego-upgrade-stability-tests), there will always be an app pushed right after the initial configuration (`C0`) is deployed and constantly checked for routability, apart for during the upgrade of the Router itself. -->
 
-## Long running tests<a id="sec-2-1" name="sec-2-1"></a>
+<!-- ## Tests to run after each configuration update -->
 
-- As in the current [DUSTs](https://github.com/cloudfoundry/diego-upgrade-stability-tests), there will always be an app pushed right after the initial configuration (`C0`) is deployed and constantly checked for routability, apart for during the upgrade of the Router itself.
+<!-- - Run the vizzini test suite at the appropriate version to verify core functionality of the Diego BBS API. This test could be structured as its own isolated context, in which it starts the appropriate versions of the components and runs the vizzini tests, instead of coupling it to the sequential upgrade of the components. -->
 
-## Tests to run after each configuration update<a id="sec-2-2" name="sec-2-2"></a>
+# Test configurations
 
-- Run the vizzini test suite at the appropriate version to verify core functionality of the Diego BBS API. This test could be structured as its own isolated context, in which it starts the appropriate versions of the components and runs the vizzini tests, instead of coupling it to the sequential upgrade of the components.
-
-# Test configurations<a id="sec-3" name="sec-3"></a>
+The new dusts suite separate the two concerns, explained in the following sections.
 
 We select two main configurations of importance, based on the initial major versions of the release and major architectural changes:
 
 - Diego starting at v1.0.0, configured to use Consul and global route-emitters,
 - Diego starting at v1.25.2, configured to use Locket with local route-emitters.
 
+## App Routability during Upgrades
 
-## BBS running with Consul (from v1.0.0 to develop)<a id="sec-3-1" name="sec-3-1"></a>
+This test suite checks app routability during a rolling upgrade, similar to the app poller found in [DUSTs](https://github.com/cloudfoundry/diego-upgrade-stability-tests)
+
+### BBS running with Consul (from v1.0.0 to develop)
 
 - Initial Diego version is v1.0.0.
 - Infrastructure components: MySQL database, NATS, Consul.
 - Route-emitter is configured in global mode, with Consul lock.
 - Each Cell includes the Diego cell rep and garden-runc.
 
-| Configuration | BBS | BBS Client (Vizzini) | Router     | SSH proxy + Auctioneer | Cells (2) | Notes                         |
-|---------------|-----|----------------------|------------|------------------------|-----------|-------------------------------|
-| C0            | v0  | v0                   | v0         | v0                     | v0        | Initial configuration         |
-| C1            | v1  | v0                   | v0         | v0                     | v0        | Simulates upgrading diego-api |
-| C2            | v1  | v1                   | v0         | v0                     | v0        | Simulates API upgrading       |
-| C3            | v1  | v1                   | v1         | v0                     | v0        | Simulates Router upgrading    |
-| C4            | v1  | v1                   | v1         | v1                     | v0        | Simulates scheduler upgrading |
-| C5            | v1  | v1                   | v1         | v1                     | v1        | Simulates cell upgrading      |
+| Configuration | BBS | BBS Client (Vizzini) | Router | Auctioneer | Cell 0 | Cell  1 | RouteEmitter | Notes                             |
+|---------------|-----|----------------------|--------|------------|--------|---------|--------------|-----------------------------------|
+| C0            | v0  | v0                   | v0     | v0         | v0     | v0      | v0           | Initial configuration             |
+| C1            | v1  | v0                   | v0     | v0         | v0     | v0      | v0           | Simulates upgrading diego-api     |
+| C2            | v1  | v1                   | v0     | v0         | v0     | v0      | v0           | Simulates API upgrading           |
+| C3            | v1  | v1                   | v1     | v0         | v0     | v0      | v0           | Simulates Router upgrading        |
+| C4            | v1  | v1                   | v1     | v1         | v0     | v0      | v0           | Simulates scheduler upgrading     |
+| C5'           | v1  | v1                   | v1     | v1         | v1     | v0      | v0           | Simulates Cell evacuation|upgrade |
+| C5            | v1  | v1                   | v1     | v1         | v1     | v1      | v0           | Simulates cell evacuation|upgrade |
+| C6            | v1  | v1                   | v1     | v1         | v1     | v1      | v1           | Simulates route-emitter upgrade   |
 
-
-## BBS running with Locket (from v1.25.2 to develop)<a id="sec-3-2" name="sec-3-2"></a>
+### BBS running with Locket (from v1.25.2 to develop)
 
 - Initial Diego version is v1.25.2.
 - Infrastructure components: MySQL database, NATS.
-- Route-emitter is configured in local mode, with Consul lock.
+- Route-emitter is configured in local mode.
 - Each Cell includes the Diego cell rep, garden-runc, grootfs, and local route-emitters.
 
-| Configuration | Locket | BBS | BBS Client (Vizzini) | Router     | SSH proxy + Auctioneer | Cells (2) | Notes                         |
-|---------------|--------|-----|----------------------|------------|------------------------|-----------|-------------------------------|
-| C0            | v0     | v0  | v0                   | v0         | v0                     | v0        | Initial configuration         |
-| C1            | v1     | v0  | v0                   | v0         | v0                     | v0        | Simulates upgrading diego-api |
-| C2            | v0     | v1  | v0                   | v0         | v0                     | v0        |                               |
-| C3            | v1     | v1  | v1                   | v0         | v0                     | v0        | Simulates API upgrading       |
-| C4            | v1     | v1  | v1                   | v1         | v0                     | v0        | Simulates Router upgrading    |
-| C5            | v1     | v1  | v1                   | v1         | v1                     | v0        | Simulates scheduler upgrading |
-| C6            | v1     | v1  | v1                   | v1         | v1                     | v1        | Simulates cell upgrading      |
+| Configuration | Locket | BBS | BBS Client (Vizzini) | Router | Auctioneer | Cell 0 | Cell 1 | Notes                               |
+|---------------|--------|-----|----------------------|--------|------------|--------|--------|-------------------------------------|
+| C0            | v0     | v0  | v0                   | v0     | v0         | v0     | v0     | Initial configuration               |
+| C1            | v1     | v0  | v0                   | v0     | v0         | v0     | v0     | Simulates upgrading diego-api       |
+| C2            | v0     | v1  | v0                   | v0     | v0         | v0     | v0     |                                     |
+| C3            | v1     | v1  | v1                   | v0     | v0         | v0     | v0     | Simulates API upgrading             |
+| C4            | v1     | v1  | v1                   | v1     | v0         | v0     | v0     | Simulates Router upgrading          |
+| C5            | v1     | v1  | v1                   | v1     | v1         | v0     | v0     | Simulates scheduler upgrading       |
+| C6'           | v1     | v1  | v1                   | v1     | v1         | v1     | v0     | Simulates cell evacuation|upgrading |
+| C6            | v1     | v1  | v1                   | v1     | v1         | v1     | v1     | Simulates cell evacuation|upgrading |
 
+## Smoke Tests
 
-## Notes<a id="sec-3-3" name="sec-3-3"></a>
+This test suite ensures different configurations are compatible, by running vizzini against each configuration spearately.
+
+### BBS running with Consul (from v1.0.0 to develop)
+
+- Initial Diego version is v1.0.0.
+- Infrastructure components: MySQL database, NATS, Consul.
+- Route-emitter is configured in global mode, with Consul lock.
+- Each Cell includes the Diego cell rep and garden-runc.
+
+| Configuration | BBS | BBS Client (Vizzini) | Router | SSH proxy + Auctioneer | Cell | RouteEmitter | Notes                           |
+|---------------|-----|----------------------|--------|------------------------|------|--------------|---------------------------------|
+| C0            | v0  | v0                   | v0     | v0                     | v0   | v0           | Initial configuration           |
+| C1            | v1  | v0                   | v0     | v0                     | v0   | v0           | Simulates upgrading diego-api   |
+| C2            | v1  | v1                   | v0     | v0                     | v0   | v0           | Simulates API upgrading         |
+| C3            | v1  | v1                   | v1     | v0                     | v0   | v0           | Simulates Router upgrading      |
+| C4            | v1  | v1                   | v1     | v1                     | v0   | v0           | Simulates scheduler upgrading   |
+| C5            | v1  | v1                   | v1     | v1                     | v1   | v0           | Simulates cell upgrade          |
+| C6            | v1  | v1                   | v1     | v1                     | v1   | v1           | Simulates route-emitter upgrade |
+
+### BBS running with Locket (from v1.25.2 to develop)
+
+- Initial Diego version is v1.25.2.
+- Infrastructure components: MySQL database, NATS.
+- Route-emitter is configured in local mode.
+- Each Cell includes the Diego cell rep, garden-runc, grootfs, and local route-emitters.
+
+| Configuration | Locket | BBS | BBS Client (Vizzini) | Router | SSH proxy + Auctioneer | Cell | Notes                         |
+|---------------|--------|-----|----------------------|--------|------------------------|------|-------------------------------|
+| C0            | v0     | v0  | v0                   | v0     | v0                     | v0   | Initial configuration         |
+| C1            | v1     | v0  | v0                   | v0     | v0                     | v0   | Simulates upgrading diego-api |
+| C2            | v0     | v1  | v0                   | v0     | v0                     | v0   |                               |
+| C3            | v1     | v1  | v1                   | v0     | v0                     | v0   | Simulates API upgrading       |
+| C4            | v1     | v1  | v1                   | v1     | v0                     | v0   | Simulates Router upgrading    |
+| C5            | v1     | v1  | v1                   | v1     | v1                     | v0   | Simulates scheduler upgrading |
+| C6            | v1     | v1  | v1                   | v1     | v1                     | v1   | Simulates cell upgrading      |
+
+## Notes
 
 - The above configurations have the added benefit of testing the contract between rep and BBS regarding cell presences (namely, that the newer BBS can still parse old rep cell presences in both Consul or Locket).
 - Deploy only one instance for all instance groups except the Cell to ensure routability to the test app at all times.
@@ -79,7 +118,7 @@ We select two main configurations of importance, based on the initial major vers
 - The SSH proxy and auctioneer do not communicate with each other and exist on the same VM, hence we update them at the same time.
 
 
-# Concerns<a id="sec-4" name="sec-4"></a>
+# Concerns
 
 - Routing: We think testing HTTP routing is sufficient, as that is the main routing tier of importance in CF at present. The Routing team is primarily responsible for ensuring interoperability of the clients and servers in the routing control plane, but because routing is of such key importance and because diego-release contains the route-emitter we do choose to test it in the DUSTs.
 - Locket: We test with a separate configuration that includes Locket because of the importance of this architectural change.

--- a/proposals/release-versioning-testing-v2.md
+++ b/proposals/release-versioning-testing-v2.md
@@ -35,16 +35,16 @@ As in the current [DUSTs](https://github.com/cloudfoundry/diego-upgrade-stabilit
 - Route-emitter is configured in global mode, with Consul lock.
 - Each Cell includes the Diego cell rep and garden-runc.
 
-| Configuration | BBS | BBS Client (Vizzini) | Router | Auctioneer | Cell 0 | Cell  1 | RouteEmitter | Notes                             |
-|---------------|-----|----------------------|--------|------------|--------|---------|--------------|-----------------------------------|
-| C0            | v0  | v0                   | v0     | v0         | v0     | v0      | v0           | Initial configuration             |
-| C1            | v1  | v0                   | v0     | v0         | v0     | v0      | v0           | Simulates upgrading diego-api     |
-| C2            | v1  | v1                   | v0     | v0         | v0     | v0      | v0           | Simulates API upgrading           |
-| C3            | v1  | v1                   | v1     | v0         | v0     | v0      | v0           | Simulates Router upgrading        |
-| C4            | v1  | v1                   | v1     | v1         | v0     | v0      | v0           | Simulates scheduler upgrading     |
-| C5'           | v1  | v1                   | v1     | v1         | v1     | v0      | v0           | Simulates Cell evacuation|upgrade |
-| C5            | v1  | v1                   | v1     | v1         | v1     | v1      | v0           | Simulates cell evacuation|upgrade |
-| C6            | v1  | v1                   | v1     | v1         | v1     | v1      | v1           | Simulates route-emitter upgrade   |
+| Configuration | BBS | BBS Client | Router | Auctioneer | Cell 0 | Cell  1 | RouteEmitter | Notes                           |         |
+|---------------|-----|------------|--------|------------|--------|---------|--------------|---------------------------------|---------|
+| C0            | v0  | v0         | v0     | v0         | v0     | v0      | v0           | Initial configuration           |         |
+| C1            | v1  | v0         | v0     | v0         | v0     | v0      | v0           | Simulates upgrading diego-api   |         |
+| C2            | v1  | v1         | v0     | v0         | v0     | v0      | v0           | Simulates API upgrading         |         |
+| C3            | v1  | v1         | v1     | v0         | v0     | v0      | v0           | Simulates Router upgrading      |         |
+| C4            | v1  | v1         | v1     | v1         | v0     | v0      | v0           | Simulates scheduler upgrading   |         |
+| C5'           | v1  | v1         | v1     | v1         | v1     | v0      | v0           | Simulates Cell evacuation       | upgrade |
+| C5            | v1  | v1         | v1     | v1         | v1     | v1      | v0           | Simulates cell evacuation       | upgrade |
+| C6            | v1  | v1         | v1     | v1         | v1     | v1      | v1           | Simulates route-emitter upgrade |         |
 
 ### BBS running with Locket (from v1.25.2 to develop)
 
@@ -75,15 +75,15 @@ Run the vizzini test suite at the appropriate version to verify core functionali
 - Route-emitter is configured in global mode, with Consul lock.
 - Each Cell includes the Diego cell rep and garden-runc.
 
-| Configuration | BBS | BBS Client (Vizzini) | Router | SSH proxy + Auctioneer | Cell | RouteEmitter | Notes                           |
-|---------------|-----|----------------------|--------|------------------------|------|--------------|---------------------------------|
-| C0            | v0  | v0                   | v0     | v0                     | v0   | v0           | Initial configuration           |
-| C1            | v1  | v0                   | v0     | v0                     | v0   | v0           | Simulates upgrading diego-api   |
-| C2            | v1  | v1                   | v0     | v0                     | v0   | v0           | Simulates API upgrading         |
-| C3            | v1  | v1                   | v1     | v0                     | v0   | v0           | Simulates Router upgrading      |
-| C4            | v1  | v1                   | v1     | v1                     | v0   | v0           | Simulates scheduler upgrading   |
-| C5            | v1  | v1                   | v1     | v1                     | v1   | v0           | Simulates cell upgrade          |
-| C6            | v1  | v1                   | v1     | v1                     | v1   | v1           | Simulates route-emitter upgrade |
+| Configuration | BBS | BBS Client | Router | SSH proxy + Auctioneer | Cell | RouteEmitter | Notes                           |
+|---------------|-----|------------|--------|------------------------|------|--------------|---------------------------------|
+| C0            | v0  | v0         | v0     | v0                     | v0   | v0           | Initial configuration           |
+| C1            | v1  | v0         | v0     | v0                     | v0   | v0           | Simulates upgrading diego-api   |
+| C2            | v1  | v1         | v0     | v0                     | v0   | v0           | Simulates API upgrading         |
+| C3            | v1  | v1         | v1     | v0                     | v0   | v0           | Simulates Router upgrading      |
+| C4            | v1  | v1         | v1     | v1                     | v0   | v0           | Simulates scheduler upgrading   |
+| C5            | v1  | v1         | v1     | v1                     | v1   | v0           | Simulates cell upgrade          |
+| C6            | v1  | v1         | v1     | v1                     | v1   | v1           | Simulates route-emitter upgrade |
 
 ### BBS running with Locket (from v1.25.2 to develop)
 

--- a/proposals/release-versioning-testing-v2.md
+++ b/proposals/release-versioning-testing-v2.md
@@ -11,15 +11,9 @@ We revisit release version testing and the current upgrade testing strategy (the
 
 ## Aspects remaining from [the previous version](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md)
 
-<!-- # Tests to run -->
-
-<!-- ## Long running tests -->
-
-<!-- - As in the current [DUSTs](https://github.com/cloudfoundry/diego-upgrade-stability-tests), there will always be an app pushed right after the initial configuration (`C0`) is deployed and constantly checked for routability, apart for during the upgrade of the Router itself. -->
-
-<!-- ## Tests to run after each configuration update -->
-
-<!-- - Run the vizzini test suite at the appropriate version to verify core functionality of the Diego BBS API. This test could be structured as its own isolated context, in which it starts the appropriate versions of the components and runs the vizzini tests, instead of coupling it to the sequential upgrade of the components. -->
+- We perceive there to be value in maintaining deployments at different heterogeneous combinations of versions and running an appropriate set of tests to validate functionality, instead of coincidentally running tests while proceeding through an upgrade of a single BOSH deployment.
+- Operational guarantees have not changed regarding compatibility of versions of diego-release. Refer to [this section](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md#operational-guarantees) in the original version of the document.
+- We still do not require testing every possible upgrade path (i.e. every `(V0, V1)` pair) See [this section](https://github.com/cloudfoundry/diego-dev-notes/blob/master/proposals/release-versioning-testing.md#selection-of-versions-for-testing) for the rationale.
 
 # Test configurations
 
@@ -32,7 +26,7 @@ We select two main configurations of importance, based on the initial major vers
 
 ## App Routability during Upgrades
 
-This test suite checks app routability during a rolling upgrade, similar to the app poller found in [DUSTs](https://github.com/cloudfoundry/diego-upgrade-stability-tests)
+As in the current [DUSTs](https://github.com/cloudfoundry/diego-upgrade-stability-tests), there will always be an app pushed right after the initial configuration (C0) is deployed and constantly checked for routability, apart from during the upgrade of the Router itself.
 
 ### BBS running with Consul (from v1.0.0 to develop)
 
@@ -72,7 +66,7 @@ This test suite checks app routability during a rolling upgrade, similar to the 
 
 ## Smoke Tests
 
-This test suite ensures different configurations are compatible, by running vizzini against each configuration spearately.
+Run the vizzini test suite at the appropriate version to verify core functionality of the Diego BBS API. This test could be structured as its own isolated context, in which it starts the appropriate versions of the components and runs the vizzini tests, instead of coupling it to the sequential upgrade of the components.
 
 ### BBS running with Consul (from v1.0.0 to develop)
 


### PR DESCRIPTION
based on what we learned so far, we decided to split the smoke tests and
routability tests into different sections. we also removed some of the jobs
that don't make sense in the routability test or the smoke tests. For example
the routability test doesn't make any assertion on the availibility of the ssh
proxy, therefore it was removed. Similarly, we don't need more than one Cell in
the smoke tests.

Signed-off-by: John Shahid <jvshahid@gmail.com>